### PR TITLE
Refactor/diary get monthly 월간 다이어리 조회 범위 수정

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:21-jdk-slim
 
 # 빌드된 애플리케이션 JAR 파일을 컨테이너에 복사
-COPY build/libs/sparkle-note-0.0.1-SNAPSHOT.jar app.jar
+COPY build/libs/daily-emotion-0.0.1-SNAPSHOT.jar app.jar
 
 # 포트 설정 (백엔드 애플리케이션이 사용할 포트)
 EXPOSE 8080

--- a/src/main/java/com/dailyemotion/diary/service/DiaryService.java
+++ b/src/main/java/com/dailyemotion/diary/service/DiaryService.java
@@ -104,10 +104,14 @@ public class DiaryService {
 
         // month 형식이 "yyyyMM"로 6자리인지 검증
         invalidMonth(month);
-        // 시작 날짜: yyyyMM + 01
-        LocalDate startDate = LocalDate.parse(month + "01", DateTimeFormatter.ofPattern("yyyyMMdd"));
-        // 종료 날짜: 해당 월의 마지막 날
-        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        // 입력받은 month의 첫날 계산
+        LocalDate targetMonthStart = LocalDate.parse(month + "01", DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        // 시작 날짜: 입력받은 월의 이전 달의 첫날
+        LocalDate startDate = targetMonthStart.minusMonths(1).withDayOfMonth(1);
+        // 종료 날짜: 입력받은 월의 다음 달의 마지막 날
+        LocalDate endDate = targetMonthStart.plusMonths(1).withDayOfMonth(targetMonthStart.plusMonths(1).lengthOfMonth());
 
         // 범위 쿼리 실행 후 DTO 변환
         List<Diary> diaries = diaryRepository.findByDateBetween(startDate, endDate);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #34 

## #️⃣ 작업 내용

> 월간 다이어리 조회 범위 수정 (1개월 -> 3개월)
> 기존 방식에서 큰 차이점은 없음
> 기존: 요청일자(202501) -> 20250101 ~ 20250131 까지의 데이터 조회
> 변경 후: 요청일자(202501) -> 20241201 ~ 20250228 까지의 데이터 조회

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
