### PR TITLE
Chore/imageUpload 관련 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,14 @@ out/
 ### VS Code ###
 .vscode/
 
-# Firebase
-firebaseServiceAccountKey.json
+
 
 # .env
 env/*
 
 # db
 db/
+
+# gcp
+gcp-service-account.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,5 @@ env/*
 db/
 
 # gcp
-gcp-service-account.json
+gcp-key.json
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'com.google.cloud:google-cloud-storage:2.32.1'
 
 	//JWT 모듈
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/dailyemotion/common/config/GcpConfig.java
+++ b/src/main/java/com/dailyemotion/common/config/GcpConfig.java
@@ -1,0 +1,28 @@
+package com.dailyemotion.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class GcpConfig {
+
+    @Bean
+    public Storage storage() throws IOException {
+
+        ClassPathResource resource = new ClassPathResource("gcp-key.json");
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+        String projectId = "daily-emotion-b3d59";
+        return StorageOptions.newBuilder()
+                .setProjectId(projectId)
+                .setCredentials(credentials)
+                .build()
+                .getService();
+    }
+}
+

--- a/src/main/java/com/dailyemotion/diary/controller/DiaryController.java
+++ b/src/main/java/com/dailyemotion/diary/controller/DiaryController.java
@@ -11,9 +11,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -96,5 +98,12 @@ public class DiaryController {
             @PathVariable(name = "month") String month) {
         List<DiaryGetResDto> diaryGetResDto = diaryService.getMonthlyDiary(month);
         return ResponseEntity.status(HttpStatus.OK).body(diaryGetResDto);
+    }
+
+    @Operation(summary = "다이어리 이미지 업로드")
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file) {
+        String imageUrl = diaryService.uploadImageToGcs(file);
+        return ResponseEntity.ok(imageUrl);
     }
 }

--- a/src/main/java/com/dailyemotion/diary/dto/response/ImageUploadResDto.java
+++ b/src/main/java/com/dailyemotion/diary/dto/response/ImageUploadResDto.java
@@ -1,0 +1,11 @@
+package com.dailyemotion.diary.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class ImageUploadResDto {
+
+    public String imageUrl;
+    
+}

--- a/src/main/java/com/dailyemotion/diary/service/DiaryService.java
+++ b/src/main/java/com/dailyemotion/diary/service/DiaryService.java
@@ -18,6 +18,7 @@ import com.dailyemotion.user.oAuth2.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -40,6 +41,7 @@ public class DiaryService {
     private final UserRepository userRepository;
     private final TagService tagService;
     private final TagRepository tagRepository;
+    private final ImageService imageService;
 
     public DiaryResDto createDiary(LocalDate date, DiaryReqDto diaryReqDto) {
 
@@ -157,7 +159,7 @@ public class DiaryService {
     }
 
     // 해당 다이어리를 작성한 유저가 현재 로그인한 유저와 일치하는지 확인하는 메소드
-    private void isDiaryOwner (Diary diary) {
+    private void isDiaryOwner(Diary diary) {
         String username = getCustomOAuth2User();
         String diaryUsername = diary.getUser().getUsername();
 
@@ -165,8 +167,9 @@ public class DiaryService {
             throw new UserException(USER_NOT_MATCHED);
         }
     }
+
     // 다이어리가 존재하지 않을 경우 예외를 던지는 메소드
-    private void getDiaryOrThrow (Diary diary) {
+    private void getDiaryOrThrow(Diary diary) {
         if (diary == null) {
             throw new DiaryException(DIARY_NOT_FOUND);
         }
@@ -176,5 +179,9 @@ public class DiaryService {
         if (month == null || month.length() != 6) {
             throw new DiaryException(INVALID_MONTH_DATE_FORMAT);
         }
+    }
+
+    public String uploadImageToGcs(MultipartFile file) {
+        return imageService.uploadImage(file);
     }
 }

--- a/src/main/java/com/dailyemotion/diary/service/ImageService.java
+++ b/src/main/java/com/dailyemotion/diary/service/ImageService.java
@@ -1,0 +1,38 @@
+package com.dailyemotion.diary.service;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final Storage storage;
+    private static final String BUCKET_NAME = "dailyemotion_buket"; //실수로 buket..으로 지정했어요
+
+    public String uploadImage(MultipartFile file) {
+        try {
+            // UUID로 고유한 파일명 생성
+            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+            // 파일 정보 설정
+            BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, fileName)
+                    .setContentType(file.getContentType())
+                    .build();
+
+            // 파일 업로드
+            storage.create(blobInfo, file.getInputStream());
+
+            // 업로드된 파일의 공개 URL 반환
+            return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, fileName);
+
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   datasource:
     url: jdbc:mariadb://localhost:3306/daily_emotion


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #37 

## #️⃣ 작업 내용

우선 gcp stoarge 관련 설정을 완료하였고, 이를 서버와 연결 하였습니다.

1. 엔드포인트를 따로 구분하여 /images endpoint에서는 이미지를 우선 따로 클라이언트 측에서 받고,
2.  storage에 저장이후 url을 반환하여 클라이언트에 돌려주고 , 
3. 그 이후 post/diary/{date}에 content와 emotion tag와 함꼐 imageUrl을 한꺼번에 다시 요청 한 이후 일기가 등록 되는 방안으로 구현하였습니다.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

1. 이미지 업로드
<img width="1057" alt="스크린샷 2025-02-02 오후 8 00 55" src="https://github.com/user-attachments/assets/2a134b5b-c882-4f90-9fc9-e24acde0e437" />

2. 클라우드에 저장
<img width="706" alt="스크린샷 2025-02-02 오후 8 01 22" src="https://github.com/user-attachments/assets/5603ee8f-7b9b-4612-953f-48ecd2ec1156" />

3. post요청으로 일기 등록 
<img width="1058" alt="스크린샷 2025-02-02 오후 8 02 08" src="https://github.com/user-attachments/assets/a06c4ace-a345-4a1d-a1e3-cedb910d6279" />

4.DB에 저장 확인
<img width="758" alt="스크린샷 2025-02-02 오후 8 02 44" src="https://github.com/user-attachments/assets/bc33f3b5-7800-48f5-8541-62facc34ba14" />

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
