### PR TITLE
Feat/connect-token-redis 리팩토링

### DIFF
--- a/src/main/java/com/dailyemotion/common/config/SecurityConfig.java
+++ b/src/main/java/com/dailyemotion/common/config/SecurityConfig.java
@@ -186,6 +186,7 @@ public class SecurityConfig {
 
                 // 사용자 정보
                 antMatcher(GET, "/user/profile"),
+                antMatcher(POST, "/logout"),
 
                 // 통계/리포트
                 antMatcher(GET, "/reports/emotions/{year}/{month}"),

--- a/src/main/java/com/dailyemotion/common/config/SecurityConfig.java
+++ b/src/main/java/com/dailyemotion/common/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.dailyemotion.user.handler.CustomSuccessHandler;
 import com.dailyemotion.user.jwt.JWTFilter;
 import com.dailyemotion.user.jwt.JWTUtil;
 import com.dailyemotion.user.oAuth2.CustomOAuth2UserService;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -67,6 +69,13 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+
+    @PostConstruct
+    public void enableAuthContextPropagation() {
+        SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
+    }
+
 
     // ✅ OAuth2 로그인 설정 수정
     private void configureOAuth2(HttpSecurity http) throws Exception {

--- a/src/main/java/com/dailyemotion/user/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/dailyemotion/user/handler/CustomLogoutHandler.java
@@ -20,11 +20,9 @@ public class CustomLogoutHandler implements LogoutHandler {
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         // 클라이언트로부터 리프레시 토큰을 받아와서 처리
         String refreshToken = request.getHeader("RefreshToken");
-
         if (refreshToken != null) {
-            // Redis에 리프레시 토큰을 0초 유효기간으로 설정하여 즉시 만료
-            redisTemplate.opsForValue().set(refreshToken, "loggedOut", 1, TimeUnit.SECONDS);
-            // 0은 RuntimeException 발생으로 1로 변경
+            String key = "blacklist:refreshToken:" + refreshToken;
+            redisTemplate.opsForValue().set(key, "loggedOut", 7, TimeUnit.DAYS);
         }
     }
 }

--- a/src/main/java/com/dailyemotion/user/service/UserService.java
+++ b/src/main/java/com/dailyemotion/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.dailyemotion.user.oAuth2.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -31,12 +32,20 @@ public class UserService {
 
     private final JWTUtil jwtUtil;
     private final UserRepository userRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
     /**
      * 토큰을 재발급 하는 메소드
      */
     public TokenResponseDTO refreshToken(String refreshToken) {
         // 리프레시 토큰 검증
         if (!jwtUtil.isValidToken(refreshToken)) {
+            throw new UserException(TOKEN_IS_NOT_VALID);
+        }
+
+        // 블랙리스트에 해당 refreshToken이 있다면 토큰 발급 X
+        String blackListKey = "blacklist:refreshToken:" + refreshToken;
+        Boolean isBlacklisted = redisTemplate.hasKey(blackListKey);
+        if (Boolean.TRUE.equals(isBlacklisted)) {
             throw new UserException(TOKEN_IS_NOT_VALID);
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #45 

## #️⃣ 작업 내용

> 로그아웃
> 1. 로그아웃 버튼 -> /logout API 호출 (프론트) (Header : RefreshToken, AccessToken)
> 2. RefreshToken을 추출하여 Redis에 저장 (blacklist:refreshToken: + RefreshToken 형태)
> 3. /token/refresh 시, 블랙리스트에 해당 Refresh Token이 있는 경우 예외 발생
> 4. Redis 보관 기간 (Refresh Token의 만료시간과 동일하게 처리)

## #️⃣ 테스트 결과
 
<img width="924" alt="image" src="https://github.com/user-attachments/assets/03abfa7e-5406-4df4-ab1b-e7c4b7bafe43" />


## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 유의사항
- 현재 프론트에서 /logout 에 대한 처리가 없어 Postman으로 API 테스트를 진행하였습니다. 
- 내용은 전달해둔 상태이고 추후 반영되면 배포환경에서도 확인 가능합니다.